### PR TITLE
chore: Move to latest gateway-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <gravitee-plugin-policy.version>1.0.0</gravitee-plugin-policy.version>
         <gravitee-plugin-resource.version>1.0.0</gravitee-plugin-resource.version>
         <gravitee-policy-api.version>1.0.0</gravitee-policy-api.version>
-        <gravitee-gateway-api.version>1.1.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.2.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-reporter-api.version>1.1.0</gravitee-reporter-api.version>
         <vertx.version>3.3.3</vertx.version>
         <jetty.version>9.3.3.v20150827</jetty.version>


### PR DESCRIPTION
Closes gravitee-io/issues#356