### PR TITLE
fix(sync): Set log level to lower level when dealing with sharding tags

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncManager.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncManager.java
@@ -204,11 +204,11 @@ public class SyncManager {
                                         ));
 
                 if (!hasMatchingTags) {
-                    logger.info("The API {} has been ignored because not in configured tags {}", api.getName(), tagList);
+                    logger.debug("The API {} has been ignored because not in configured tags {}", api.getName(), tagList);
                 }
                 return hasMatchingTags;
             }
-            logger.info("Tags {} are configured on gateway instance but not found on the API {}", tagList, api.getName());
+            logger.debug("Tags {} are configured on gateway instance but not found on the API {}", tagList, api.getName());
             return false;
         }
         // no tags configured on this gateway instance


### PR DESCRIPTION
Closes gravitee-io/issues#553