### PR TITLE
feat(healthcheck): Update default port from 8092 to 18082

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -127,7 +127,7 @@ services:
   core:
     http:
       enabled: true
-      port: 8092
+      port: 18082
       host: localhost
       authentication:
         type: basic


### PR DESCRIPTION
Closes gravitee-io/issues#712