### PR TITLE
fix(gateway): Allow disabling of authentication for internal node API

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-core/src/main/java/io/gravitee/gateway/services/http/configuration/HttpServerConfiguration.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-core/src/main/java/io/gravitee/gateway/services/http/configuration/HttpServerConfiguration.java
@@ -32,6 +32,9 @@ public class HttpServerConfiguration {
     @Value("${services.core.http.host:localhost}")
     private String host;
 
+    @Value("${services.core.http.authentication.type:basic}")
+    private String authenticationType;
+
     public boolean isEnabled() {
         return enabled;
     }
@@ -55,4 +58,13 @@ public class HttpServerConfiguration {
     public void setHost(String host) {
         this.host = host;
     }
+
+    public String getAuthenticationType() {
+      return authenticationType;
+    }
+
+    public void setAuthenticationType(String authenticationType) {
+      this.authenticationType = authenticationType;
+    }
+
 }

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -130,6 +130,10 @@ services:
       port: 18082
       host: localhost
       authentication:
+        # authentication type to be used for the core services
+        # - none : to disable authentication
+        # - basic : to use basic authentication
+        # default is "basic"
         type: basic
         users:
           admin: adminadmin


### PR DESCRIPTION
fix(gateway): Allow disabling of authentication for internal node API based on config file

closes gravitee-io/issues#791