### PR TITLE
fix(gateway): Do not call stream handler if the stream policy returns…

### DIFF
--- a/gravitee-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/StreamablePolicyChain.java
+++ b/gravitee-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/StreamablePolicyChain.java
@@ -81,8 +81,8 @@ public abstract class StreamablePolicyChain extends PolicyChain {
 
         ReadWriteStream<Buffer> tailPolicyStreamer = previousPolicyStreamer;
         if (streamablePolicyHandlerChain != null && tailPolicyStreamer != null) {
-            tailPolicyStreamer.bodyHandler(bodyPart -> bodyHandler.handle(bodyPart));
-            tailPolicyStreamer.endHandler(result -> endHandler.handle(result));
+            tailPolicyStreamer.bodyHandler(bodyPart -> {if (bodyHandler != null) bodyHandler.handle(bodyPart);});
+            tailPolicyStreamer.endHandler(result -> {if (endHandler != null) endHandler.handle(result);});
         }
     }
 


### PR DESCRIPTION
… an empty / null stream

Closes gravitee-io/issues#1115