### PR TITLE
fix: Technical API does not expose /_node/apis anymore

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/pom.xml
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>gravitee-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-management</artifactId>
+            <version>${gravitee-node.version}</version>
+        </dependency>
+
         <!-- Vert.x -->
         <dependency>
             <groupId>io.vertx</groupId>

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApiManagementEndpoint.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApiManagementEndpoint.java
@@ -18,10 +18,12 @@ package io.gravitee.gateway.handlers.api.manager.endpoint;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.handlers.api.definition.Api;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
@@ -34,12 +36,22 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ApiManagementEndpoint implements Handler<RoutingContext> {
+public class ApiManagementEndpoint implements Handler<RoutingContext>, ManagementEndpoint {
 
     private final Logger LOGGER = LoggerFactory.getLogger(ApiManagementEndpoint.class);
 
     @Autowired
     private ApiManager apiManager;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/apis/:apiId";
+    }
 
     @Override
     public void handle(RoutingContext ctx) {

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApisManagementEndpoint.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/ApisManagementEndpoint.java
@@ -18,10 +18,12 @@ package io.gravitee.gateway.handlers.api.manager.endpoint;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import io.gravitee.common.http.HttpHeaders;
+import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
 import io.gravitee.gateway.handlers.api.manager.endpoint.model.ListApiEntity;
+import io.gravitee.node.management.http.endpoint.ManagementEndpoint;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
@@ -37,12 +39,22 @@ import java.util.stream.Collectors;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ApisManagementEndpoint implements Handler<RoutingContext> {
+public class ApisManagementEndpoint implements Handler<RoutingContext>, ManagementEndpoint {
 
     private final Logger LOGGER = LoggerFactory.getLogger(ApisManagementEndpoint.class);
 
     @Autowired
     private ApiManager apiManager;
+
+    @Override
+    public HttpMethod method() {
+        return HttpMethod.GET;
+    }
+
+    @Override
+    public String path() {
+        return "/apis";
+    }
 
     @Override
     public void handle(RoutingContext ctx) {

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/NodeApisEndpointInitializer.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/manager/endpoint/NodeApisEndpointInitializer.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.handlers.api.manager.endpoint;
+
+import io.gravitee.node.management.http.endpoint.ManagementEndpointManager;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * @author Azize ELAMRANI (azize.elamrani at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NodeApisEndpointInitializer {
+
+    @Autowired
+    private ManagementEndpointManager managementEndpointManager;
+
+    @Autowired
+    private ApisManagementEndpoint apisManagementEndpoint;
+    @Autowired
+    private ApiManagementEndpoint apiManagementEndpoint;
+
+    @PostConstruct
+    protected void init() {
+        managementEndpointManager.register(apisManagementEndpoint);
+        managementEndpointManager.register(apiManagementEndpoint);
+    }
+}

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/spring/ApiHandlerConfiguration.java
@@ -16,6 +16,9 @@
 package io.gravitee.gateway.handlers.api.spring;
 
 import io.gravitee.gateway.handlers.api.manager.ApiManager;
+import io.gravitee.gateway.handlers.api.manager.endpoint.ApiManagementEndpoint;
+import io.gravitee.gateway.handlers.api.manager.endpoint.ApisManagementEndpoint;
+import io.gravitee.gateway.handlers.api.manager.endpoint.NodeApisEndpointInitializer;
 import io.gravitee.gateway.handlers.api.manager.impl.ApiManagerImpl;
 import io.gravitee.gateway.handlers.api.validator.Validator;
 import io.gravitee.gateway.handlers.api.validator.ValidatorImpl;
@@ -37,5 +40,20 @@ public class ApiHandlerConfiguration {
     @Bean
     public Validator validator() {
         return new ValidatorImpl();
+    }
+
+    @Bean
+    public ApisManagementEndpoint apisManagementEndpoint() {
+        return new ApisManagementEndpoint();
+    }
+
+    @Bean
+    public ApiManagementEndpoint apiManagementEndpoint() {
+        return new ApiManagementEndpoint();
+    }
+
+    @Bean
+    public NodeApisEndpointInitializer nodeApisEndpointInitializer() {
+        return new NodeApisEndpointInitializer();
     }
 }


### PR DESCRIPTION
This closes gravitee-io/issues#1601