### PR TITLE
fix(gateway): HTTP request must be resume if exit handler is called.

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -134,6 +134,7 @@ public class ApiReactorHandler extends AbstractReactorHandler implements Templat
                 .errorHandler(failure -> handleError(context, failure, handler))
                 .streamErrorHandler(failure -> handleError(context, failure, handler))
                 .exitHandler(__ -> {
+                    context.getRequest().resume();
                     context.getResponse().end();
                     handler.handle(context.getResponse());
                 })


### PR DESCRIPTION
Closes gravitee-io/issues#1634