### PR TITLE
fix: Endpoints are not well selected when contains whitespace character

### DIFF
--- a/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/impl/TargetEndpointResolver.java
+++ b/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/endpoint/resolver/impl/TargetEndpointResolver.java
@@ -111,14 +111,20 @@ public class TargetEndpointResolver implements EndpointResolver {
             if (encodedTarget.startsWith(GroupReference.REFERENCE_PREFIX) ||
                     encodedTarget.startsWith(EndpointReference.REFERENCE_PREFIX)) {
                 // Get the full reference
-                int sep = encodedTarget.indexOf(':');
-                String sRef = encodedTarget.substring(0, encodedTarget.indexOf(':', sep + 1));
-                Reference reference = referenceRegister.get(sRef);
+                String sRef = segments[0].substring(0, segments[0].length() - 1);
+                final Reference reference = referenceRegister.get(sRef);
+
+                // A null reference has been found (unknown reference ?), returning null to the caller
+                if (reference == null) {
+                    return null;
+                }
 
                 // Get next endpoint from reference
                 Endpoint endpoint = reference.endpoint();
 
-                return createEndpoint(endpoint, encodedTarget.replaceFirst(sRef + ':', endpoint.target()));
+                int pathSepIdx = encodedTarget.indexOf('/');
+                return createEndpoint(endpoint,
+                        (pathSepIdx == -1) ? endpoint.target() : endpoint.target() + encodedTarget.substring(pathSepIdx));
             } else if (encodedTarget.startsWith(Reference.UNKNOWN_REFERENCE)) {
                 return null;
             } else {


### PR DESCRIPTION
This closes gravitee-io/issues#1679