### PR TITLE
fix(hc): do not select inherited cfg if no global config is present

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
@@ -71,7 +71,8 @@ public class EndpointHealthcheckResolver {
         // Keep only endpoints where health-check is enabled or not settled (inherit from service)
         httpEndpoints = httpEndpoints.filter(endpoint ->
                 (endpoint.getHealthCheck() == null && hcEnabled) ||
-                        (endpoint.getHealthCheck() != null && endpoint.getHealthCheck().isEnabled()));
+                        (endpoint.getHealthCheck() != null && endpoint.getHealthCheck().isEnabled() && !endpoint.getHealthCheck().isInherit()) ||
+                        (endpoint.getHealthCheck() != null && endpoint.getHealthCheck().isEnabled() && endpoint.getHealthCheck().isInherit() && hcEnabled));
 
         return httpEndpoints.map((Function<HttpEndpoint, EndpointRule>) endpoint -> new DefaultEndpointRule(
                 api.getId(),


### PR DESCRIPTION
fix gravitee-io/issues#1682