### PR TITLE
fix: Unable to connect cluster remotely

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -220,6 +220,10 @@ alerts:
   enabled: false
   default:
     enabled: false
-    hazelcast:
-      config:
-        path: ${gravitee.home}/config/hazelcast.xml
+    # must be reachable by other nodes
+    cluster:
+      host: localhost
+      port: 0
+      hazelcast:
+        config:
+          path: ${gravitee.home}/config/hazelcast.xml


### PR DESCRIPTION
This closes gravitee-io/gravitee-alert-engine#22