### PR TITLE
fix(http2): Remove connection specific header fields for HTTP2 responses

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerRequest.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerRequest.java
@@ -176,17 +176,21 @@ class VertxHttpServerRequest implements Request {
 
     @Override
     public Request bodyHandler(Handler<Buffer> bodyHandler) {
-        httpServerRequest.handler(event -> {
-            bodyHandler.handle(Buffer.buffer(event.getBytes()));
-            metrics.setRequestContentLength(metrics.getRequestContentLength() + event.length());
-        });
+        if (! httpServerRequest.isEnded()) {
+            httpServerRequest.handler(event -> {
+                bodyHandler.handle(Buffer.buffer(event.getBytes()));
+                metrics.setRequestContentLength(metrics.getRequestContentLength() + event.length());
+            });
+        }
 
         return this;
     }
 
     @Override
     public Request endHandler(Handler<Void> endHandler) {
-        httpServerRequest.endHandler(endHandler::handle);
+        if (! httpServerRequest.isEnded()) {
+            httpServerRequest.endHandler(endHandler::handle);
+        }
         return this;
     }
 

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorHandler.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxReactorHandler.java
@@ -37,7 +37,7 @@ public class VertxReactorHandler implements Handler<HttpServerRequest> {
     @Override
     public void handle(HttpServerRequest httpServerRequest) {
         final Request request = new VertxHttpServerRequest(httpServerRequest);
-        final Response response = new VertxHttpServerResponse(httpServerRequest.response(), request.metrics());
+        final Response response = new VertxHttpServerResponse(httpServerRequest, request.metrics());
 
         reactor.route(request, response, __ -> {});
     }


### PR DESCRIPTION
Closes gravitee-io/issues#1913