### PR TITLE
issue 1719 custom error payloads for the api-key policy 2/3

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -232,14 +232,16 @@ public class ApiReactorHandler extends AbstractReactorHandler implements Initial
         if (failure.message() != null) {
             try {
                 Buffer payload;
-                if (failure.contentType().equalsIgnoreCase(MediaType.APPLICATION_JSON)) {
-                    payload = Buffer.buffer(failure.message());
-                } else {
+                if (failure.contentType() == null) {
+                    // create JSON content only if no content-type is set
                     String contentAsJson = mapper.writeValueAsString(new ProcessorFailureAsJson(failure));
                     payload = Buffer.buffer(contentAsJson);
+                } else {
+                    // explicitly set content-type
+                    payload = Buffer.buffer(failure.message());
                 }
                 response.headers().set(HttpHeaders.CONTENT_LENGTH, Integer.toString(payload.length()));
-                response.headers().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+                response.headers().set(HttpHeaders.CONTENT_TYPE, failure.contentType() == null ? MediaType.APPLICATION_JSON : failure.contentType());
                 response.write(payload);
             } catch (JsonProcessingException jpe) {
                 logger.error("Unable to transform a policy result into a json payload", jpe);


### PR DESCRIPTION
This PR replaces https://github.com/gravitee-io/gravitee-gateway/pull/340 for the new branch 1.23.x.

To enable custom error payloads for the API-key policy as describted in gravitee-io/issues/issues/1719 three changes (PR's) arre needed:

1: https://github.com/gravitee-io/gravitee-policy-apikey/pull/20
Adds a configuration to the API key policy to enable custom responses.

**2: this PR**
2.1: To enable custom error payloads in processor failures the failure content type is processed correctly. Only if no content type is set the default JSON conversion is done. In PR 3 ... the default failure creation method is changed to have NO content type. So together the backward compatibility is ensured.
2.2 In the SecurityPolicyChainResolver each configured security resolver is asked if it can handle a request. In case of no API key is send to the server the API key policy can not handle the request. So the default JSON response is used. I changed this default handling by using the lowest ordered security handler to answer the request, even though it can't handle the request. In case of a secured plan it is then possible to let the policy answer the request.

3: https://github.com/gravitee-io/gravitee-policy-api/pull/10
Is needed to enable payloads different than JSON.

refs gravitee-io/issues/issues/1719
