### PR TITLE
fix(http): Since vertx 3.6.x it can happen that requests without body…

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerRequest.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerRequest.java
@@ -194,7 +194,7 @@ class VertxHttpServerRequest implements Request {
 
     @Override
     public Request endHandler(Handler<Void> endHandler) {
-        if (! httpServerRequest.isEnded()) {
+        if (! ended()) {
             httpServerRequest.endHandler(endHandler::handle);
         }
         return this;
@@ -215,5 +215,10 @@ class VertxHttpServerRequest implements Request {
     @Override
     public Metrics metrics() {
         return metrics;
+    }
+
+    @Override
+    public boolean ended() {
+        return httpServerRequest.isEnded();
     }
 }


### PR DESCRIPTION
… (e.g. a GET) are ended even while in paused-state

Closes gravitee-io/issues#2020