### PR TITLE
fix(hc): could not start an api with an empty endpoint group

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckResolver.java
@@ -52,6 +52,7 @@ public class EndpointHealthcheckResolver {
         // Filter to check only HTTP endpoints
         Stream<HttpEndpoint> httpEndpoints = api.getProxy().getGroups()
                 .stream()
+                .filter(group -> group.getEndpoints() != null)
                 .flatMap(group -> group.getEndpoints().stream())
                 .filter(endpoint -> endpoint.getType() == EndpointType.HTTP)
                 .map(endpoint -> (HttpEndpoint) endpoint);


### PR DESCRIPTION
fix gravitee-io/issues#2024