### PR TITLE
Issue/#1696 using dictionaries in endpoints

### DIFF
--- a/gravitee-gateway-http/src/test/java/io/gravite/gateway/http/endpoint/HttpEndpointFactoryTest.java
+++ b/gravitee-gateway-http/src/test/java/io/gravite/gateway/http/endpoint/HttpEndpointFactoryTest.java
@@ -56,7 +56,6 @@ public class HttpEndpointFactoryTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        ApplicationContext appContext = mock(ApplicationContext.class);
         AutowireCapableBeanFactory autowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
 
         when(appContext.getAutowireCapableBeanFactory()).thenReturn(autowireCapableBeanFactory);

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncManager.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/SyncManager.java
@@ -97,15 +97,15 @@ public class SyncManager {
         long nextLastRefreshAt = System.currentTimeMillis();
 
         try {
-            synchronizeApis(nextLastRefreshAt);
-        } catch (Exception ex) {
-            logger.error("An error occurs while synchronizing APIs", ex);
-        }
-
-        try {
             synchronizeDictionaries(nextLastRefreshAt);
         } catch (Exception ex) {
             logger.error("An error occurs while synchronizing dictionaries", ex);
+        }
+        
+        try {
+            synchronizeApis(nextLastRefreshAt);
+        } catch (Exception ex) {
+            logger.error("An error occurs while synchronizing APIs", ex);
         }
 
         lastRefreshAt = nextLastRefreshAt;


### PR DESCRIPTION
Hi guys,

I worked on implementing the usage of dictionaries in (http)endpoint definitions since this feature is very important for our company. 

The provided solution will use a robust reflection mechanism to get the provider of dictionary information available during the creation of endpoint instances. This is due to I did not want to introduce a maybe unwanted  dependency between gravitee-gateway-http project and the gravitee-gateway-dictionary project. 
If introducing this dependency will be allowed and do not break your architecture, other solutions are possible.

I am looking forward to any suggestions to improve this solution to get this feature available.

Kind regards,
Markus
