### PR TITLE
fix: Missing method when policy oauth2 fail

### DIFF
--- a/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/processor/ProcessorFailure.java
+++ b/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/processor/ProcessorFailure.java
@@ -30,4 +30,6 @@ public interface ProcessorFailure {
     String key();
 
     Map<String, Object> parameters();
+
+    String contentType();
 }

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/processor/error/SimpleFailureProcessor.java
@@ -58,10 +58,16 @@ public class SimpleFailureProcessor extends AbstractProcessor<ExecutionContext> 
 
         if (failure.message() != null) {
             try {
-                String contentAsJson = mapper.writeValueAsString(new ProcessorFailureAsJson(failure));
-                Buffer payload = Buffer.buffer(contentAsJson);
+                Buffer payload;
+                if (failure.contentType().equalsIgnoreCase(MediaType.APPLICATION_JSON)) {
+                    payload = Buffer.buffer(failure.message());
+                } else {
+                    String contentAsJson = mapper.writeValueAsString(new ProcessorFailureAsJson(failure));
+                    payload = Buffer.buffer(contentAsJson);
+                }
+
                 response.headers().set(HttpHeaders.CONTENT_LENGTH, Integer.toString(payload.length()));
-                response.headers().set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+                response.headers().set(HttpHeaders.CONTENT_TYPE, failure.contentType());
                 response.write(payload);
             } catch (JsonProcessingException jpe) {
                 // Do nothing

--- a/gravitee-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/processor/PolicyChainProcessorFailure.java
+++ b/gravitee-gateway-policy/src/main/java/io/gravitee/gateway/policy/impl/processor/PolicyChainProcessorFailure.java
@@ -51,4 +51,9 @@ public class PolicyChainProcessorFailure implements ProcessorFailure {
     public Map<String, Object> parameters() {
         return policyResult.parameters();
     }
+
+    @Override
+    public String contentType() {
+        return policyResult.contentType();
+    }
 }


### PR DESCRIPTION
This closes gravitee-io/issues#2149