### PR TITLE
fix: Reduce log level when trailing slash is missing in endpoint

### DIFF
--- a/gravitee-gateway-http/src/main/java/io/gravitee/gateway/http/endpoint/HttpEndpointFactory.java
+++ b/gravitee-gateway-http/src/main/java/io/gravitee/gateway/http/endpoint/HttpEndpointFactory.java
@@ -68,7 +68,7 @@ public final class HttpEndpointFactory extends TemplateAwareEndpointFactory<io.g
         try {
             URL url = new URL(endpoint.getTarget());
             if (url.getPath().isEmpty()) {
-                logger.warn("HTTP endpoint target URL is malformed for endpoint [{} - {}]. Set default path to '/'",
+                logger.debug("HTTP endpoint target URL is malformed for endpoint [{} - {}]. Set default path to '/'",
                         endpoint.getName(), endpoint.getTarget());
                 endpoint.setTarget(endpoint.getTarget() + '/');
             }


### PR DESCRIPTION
This closes gravitee-io/issues#2303