### PR TITLE
doc: describe how to forbid the use of api-key param/header

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -230,7 +230,8 @@ ds:
 #tenant: europe
 
 #policy:
-# Customize the api-key header and / or query parameter
+# Customize the api-key header and / or query parameter.
+# Set an empty value to prohibit its use.
 #  api-key:
 #    header: X-Gravitee-Api-Key
 #    param: api-key


### PR DESCRIPTION
fix gravitee-io/issues#2446