### PR TITLE
fix(security): Select an api-key plan even for an empty api-key query…

### DIFF
--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
@@ -71,7 +71,7 @@ public class ApiKeyAuthenticationHandler implements AuthenticationHandler, Initi
     public boolean canHandle(AuthenticationContext context) {
         final String apiKey = readApiKey(context.request());
 
-        if (apiKey == null || apiKey.isEmpty()) {
+        if (apiKey == null) {
             return false;
         }
 

--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
@@ -90,6 +90,20 @@ public class ApiKeyAuthenticationHandlerTest {
     }
 
     @Test
+    public void shouldHandleRequestUsingQueryParameters_emptyApiKey() {
+        when(authenticationContext.request()).thenReturn(request);
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.put("api-key", Collections.singletonList(""));
+        when(request.parameters()).thenReturn(parameters);
+
+        HttpHeaders headers = new HttpHeaders();
+        when(request.headers()).thenReturn(headers);
+
+        boolean handle = authenticationHandler.canHandle(authenticationContext);
+        Assert.assertTrue(handle);
+    }
+
+    @Test
     public void shouldReturnPolicies() {
         ExecutionContext executionContext = mock(ExecutionContext.class);
 


### PR DESCRIPTION
… param

Closes gravitee-io/issues#2478