### PR TITLE
fix(metrics): some use cases generates 'failed to parse api-response-…

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -200,7 +200,7 @@ public class ApiReactorHandler extends AbstractReactorHandler implements Initial
 
 
     private void handleError(ExecutionContext context, ProcessorFailure failure) {
-        if (context.request().metrics().getApiResponseTimeMs() > 0) {
+        if (context.request().metrics().getApiResponseTimeMs() > Integer.MAX_VALUE) {
             context.request().metrics().setApiResponseTimeMs(System.currentTimeMillis() -
                     context.request().metrics().getApiResponseTimeMs());
         }


### PR DESCRIPTION
…time'

fix gravitee-io/issues#2989