### PR TITLE
fix: Store metrics only if api key plan matches

### DIFF
--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
@@ -117,11 +117,8 @@ public class ApiKeyAuthenticationHandler implements AuthenticationHandler, Initi
                 return true;
             }
 
-            if (apiKey != null) {
-                request.metrics().setSecurityType(API_KEY);
-                request.metrics().setSecurityToken(apiKey);
-            }
-
+            request.metrics().setSecurityType(API_KEY);
+            request.metrics().setSecurityToken(apiKey);
             return apiKeyOptional.get().getPlan().equals(authenticationContext.getId());
         } catch (TechnicalException e) {
             // technical exception, any API key plan can be selected, the request will be rejected by the API Key policy whatsoever


### PR DESCRIPTION
Closes gravitee-io/issues#3308