### PR TITLE
fix(processor): XForwardForProcessor should handle IPv6 value

### DIFF
--- a/gravitee-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessor.java
+++ b/gravitee-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessor.java
@@ -46,8 +46,9 @@ public class XForwardForProcessor extends AbstractProcessor<ExecutionContext> {
             if (xForwardedForValues.length > 0) {
                 String xForwardFor = xForwardedForValues[0];
                 int idx = xForwardFor.indexOf(':');
+                String[] splits = xForwardFor.split(":");
 
-                xForwardFor = (idx != -1) ? xForwardFor.substring(0, idx).trim() : xForwardFor.trim();
+                xForwardFor = (idx == -1) || (splits.length > 2) ? xForwardFor.trim() : xForwardFor.substring(0, idx).trim();
 
                 // X-Forwarded-For header must be reconstructed to include the gateway host address
                 ((MutableExecutionContext) context).request(new XForwardForRequest(request, xForwardFor));

--- a/gravitee-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessorTest.java
+++ b/gravitee-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/processor/forward/XForwardForProcessorTest.java
@@ -149,4 +149,61 @@ public class XForwardForProcessorTest {
 
         Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
     }
+
+    @Test
+    public void test_with_one_X_Forward_for_in_Header_withIPv6() throws InterruptedException {
+        final CountDownLatch lock = new CountDownLatch(1);
+
+        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+        when(request.remoteAddress()).thenReturn("192.168.0.1");
+
+        new XForwardForProcessor()
+                .handler(context -> {
+                    Assert.assertTrue(context.request() instanceof XForwardForRequest);
+                    Assert.assertEquals("2001:0db8:85a3:0000:0000:8a2e:0370:7334", context.request().remoteAddress());
+                    Assert.assertEquals("2001:0db8:85a3:0000:0000:8a2e:0370:7334", context.request().metrics().getRemoteAddress());
+                    lock.countDown();
+                })
+                .handle(context);
+
+        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void test_with_one_X_Forward_for_in_Header_withIPv6_hexadecimalFormat() throws InterruptedException {
+        final CountDownLatch lock = new CountDownLatch(1);
+
+        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("2001:db8:85a3:0:0:8a2e:370:7334");
+        when(request.remoteAddress()).thenReturn("192.168.0.1");
+
+        new XForwardForProcessor()
+                .handler(context -> {
+                    Assert.assertTrue(context.request() instanceof XForwardForRequest);
+                    Assert.assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", context.request().remoteAddress());
+                    Assert.assertEquals("2001:db8:85a3:0:0:8a2e:370:7334", context.request().metrics().getRemoteAddress());
+                    lock.countDown();
+                })
+                .handle(context);
+
+        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void test_with_one_X_Forward_for_in_Header_withIPv6_hexadecimalFormat_consecutiveColons() throws InterruptedException {
+        final CountDownLatch lock = new CountDownLatch(1);
+
+        when(headers.getFirst(HttpHeaders.X_FORWARDED_FOR)).thenReturn("2001:db8:85a3::8a2e:370:7334");
+        when(request.remoteAddress()).thenReturn("192.168.0.1");
+
+        new XForwardForProcessor()
+                .handler(context -> {
+                    Assert.assertTrue(context.request() instanceof XForwardForRequest);
+                    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", context.request().remoteAddress());
+                    Assert.assertEquals("2001:db8:85a3::8a2e:370:7334", context.request().metrics().getRemoteAddress());
+                    lock.countDown();
+                })
+                .handle(context);
+
+        Assert.assertTrue(lock.await(10000, TimeUnit.MILLISECONDS));
+    }
 }


### PR DESCRIPTION
fixes gravitee-io/issues#3444