### PR TITLE
fix(api): Do not duplicate api's properties to avoid memory pressure

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProvider.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/context/ApiTemplateVariableProvider.java
@@ -39,7 +39,9 @@ public class ApiTemplateVariableProvider implements TemplateVariableProvider, In
     @Override
     public void provide(TemplateContext templateContext) {
         // Keep this variable for backward compatibility
-        templateContext.setVariable("properties", api.properties());
+        if (api.getProperties() != null) {
+            templateContext.setVariable("properties", api.getProperties().getValues());
+        }
 
         templateContext.setVariable("api", apiProperties);
     }

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/definition/Api.java
@@ -16,7 +16,6 @@
 package io.gravitee.gateway.handlers.api.definition;
 
 import io.gravitee.definition.model.Policy;
-import io.gravitee.definition.model.Property;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.plugins.resources.Resource;
 import io.gravitee.gateway.reactor.Reactable;
@@ -151,23 +150,6 @@ public class Api extends io.gravitee.definition.model.Api implements Reactable {
             }});
 
         return policies;
-    }
-
-    private Map<String, Object> properties;
-
-    @Override
-    public Map<String, Object> properties() {
-        io.gravitee.definition.model.Properties apiProperties = getProperties();
-        if (apiProperties != null && apiProperties.getProperties() != null && !apiProperties.getProperties().isEmpty()) {
-            if (properties == null) {
-                properties = apiProperties.getProperties().stream().collect(
-                        Collectors.toMap(Property::getKey, Property::getValue));
-            }
-
-            return properties;
-        }
-
-        return Collections.emptyMap();
     }
 
     @Override

--- a/gravitee-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/Reactable.java
+++ b/gravitee-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/Reactable.java
@@ -18,7 +18,6 @@ package io.gravitee.gateway.reactor;
 import io.gravitee.gateway.reactor.handler.Entrypoint;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -32,8 +31,6 @@ public interface Reactable {
     boolean enabled();
 
     <D> Set<D> dependencies(Class<D> type);
-
-    Map<String, Object> properties();
 
     List<Entrypoint> entrypoints();
 }

--- a/gravitee-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/DummyReactorHandler.java
+++ b/gravitee-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/DummyReactorHandler.java
@@ -22,7 +22,6 @@ import io.gravitee.gateway.api.Response;
 import io.gravitee.gateway.reactor.Reactable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
@@ -44,11 +43,6 @@ public class DummyReactorHandler extends AbstractReactorHandler {
 
             @Override
             public Set dependencies(Class type) {
-                return null;
-            }
-
-            @Override
-            public Map<String, Object> properties() {
                 return null;
             }
 

--- a/gravitee-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
+++ b/gravitee-gateway-reactor/src/test/java/io/gravitee/gateway/reactor/handler/ReactorHandlerRegistryTest.java
@@ -26,7 +26,6 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
@@ -224,11 +223,6 @@ public class ReactorHandlerRegistryTest {
 
         @Override
         public <D> Set<D> dependencies(Class<D> type) {
-            return null;
-        }
-
-        @Override
-        public Map<String, Object> properties() {
             return null;
         }
 


### PR DESCRIPTION
Closes gravitee-io/issues#3683