### PR TITLE
chore(dependencies): upgrade dependencies

### DIFF
--- a/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/failover/FailoverInvoker.java
+++ b/gravitee-gateway-core/src/main/java/io/gravitee/gateway/core/failover/FailoverInvoker.java
@@ -29,7 +29,7 @@ import io.gravitee.gateway.core.invoker.EndpointInvoker;
 import io.vertx.circuitbreaker.CircuitBreaker;
 import io.vertx.circuitbreaker.CircuitBreakerOptions;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,9 +55,9 @@ public class FailoverInvoker extends EndpointInvoker implements InitializingBean
     public void invoke(ExecutionContext context, ReadStream<Buffer> stream, Handler<ProxyConnection> connectionHandler) {
         ((MutableExecutionContext)context).request(new FailoverRequest(context.request()));
 
-        circuitBreaker.execute(new io.vertx.core.Handler<Future<ProxyConnection>>() {
+        circuitBreaker.execute(new io.vertx.core.Handler<Promise<ProxyConnection>>() {
             @Override
-            public void handle(Future<ProxyConnection> event) {
+            public void handle(Promise<ProxyConnection> event) {
                 FailoverInvoker.super.invoke(context, stream, proxyConnection -> {
                     proxyConnection.exceptionHandler(event::fail);
                     proxyConnection.responseHandler(response ->

--- a/gravitee-gateway-http/src/test/java/io/gravite/gateway/http/connector/VertxHttpClientTest.java
+++ b/gravitee-gateway-http/src/test/java/io/gravite/gateway/http/connector/VertxHttpClientTest.java
@@ -27,6 +27,8 @@ import io.gravitee.reporter.api.http.Metrics;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.*;
+import io.vertx.core.streams.Pipe;
+import io.vertx.core.streams.WriteStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -217,7 +219,27 @@ public class VertxHttpClientTest {
         }
 
         @Override
+        public Pipe<HttpClientResponse> pipe() {
+            return null;
+        }
+
+        @Override
+        public void pipeTo(WriteStream<HttpClientResponse> dst) {
+
+        }
+
+        @Override
+        public void pipeTo(WriteStream<HttpClientResponse> dst, Handler<AsyncResult<Void>> handler) {
+
+        }
+
+        @Override
         public HttpClientRequest setFollowRedirects(boolean followRedirects) {
+            return null;
+        }
+
+        @Override
+        public HttpClientRequest setMaxRedirects(int maxRedirects) {
             return null;
         }
 
@@ -387,6 +409,11 @@ public class VertxHttpClientTest {
         }
 
         @Override
+        public boolean reset() {
+            return false;
+        }
+
+        @Override
         public boolean reset(long code) {
             return false;
         }
@@ -403,6 +430,21 @@ public class VertxHttpClientTest {
 
         @Override
         public HttpClientRequest writeCustomFrame(int type, int flags, Buffer payload) {
+            return null;
+        }
+
+        @Override
+        public int streamId() {
+            return 0;
+        }
+
+        @Override
+        public HttpClientRequest writeCustomFrame(HttpFrame frame) {
+            return null;
+        }
+
+        @Override
+        public HttpClientRequest setStreamPriority(StreamPriority streamPriority) {
             return null;
         }
 

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/pom.xml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/pom.xml
@@ -20,6 +20,9 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <jetty92.wiremock.version>9.2.30.v20200428</jetty92.wiremock.version>
+    </properties>
 
     <parent>
         <groupId>io.gravitee.gateway.standalone</groupId>
@@ -29,6 +32,62 @@
 
     <artifactId>gravitee-gateway-standalone-container</artifactId>
     <name>Gravitee.io APIM - Gateway - Standalone - Container</name>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Need to downgrade jetty to a compatible version with wiremock (jetty is only use for tests purpose) -->
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-security</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-xml</artifactId>
+                <version>${jetty92.wiremock.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- Gravitee.io -->
@@ -193,14 +252,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-
 
         <!-- Wiremock -->
         <dependency>

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/zip/pom.xml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/zip/pom.xml
@@ -32,7 +32,8 @@
     <packaging>pom</packaging>
 
     <properties>
-        <gravitee.gateway.log.dir>${gravitee.home}/logs</gravitee.gateway.log.dir>
+        <!--suppress UnresolvedMavenProperty -->
+		<gravitee.gateway.log.dir>${gravitee.home}/logs</gravitee.gateway.log.dir>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17.1</version>
+        <version>19-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.gateway</groupId>
@@ -167,11 +167,26 @@
                 <version>${gravitee-resource-oauth2-provider-api.version}</version>
             </dependency>
 
-            <!-- Vert.x -->
+            <!-- The following dependencies are necessary to make sure the good version is resolved (else they can still be overridden by dependency management of transitive dependencies) -->
             <dependency>
-                <groupId>io.vertx</groupId>
-                <artifactId>vertx-core</artifactId>
-                <version>${vertx.version}</version>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.integration</groupId>
+                <artifactId>spring-integration-xml</artifactId>
+                <version>${spring-integration.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -228,18 +243,17 @@
         <gravitee-reporter-api.version>1.17.1</gravitee-reporter-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
-        <jackson.version>2.10.3</jackson.version>
-        <jetty.version>9.2.24.v20180105</jetty.version>
-        <httpclient.version>4.5.7</httpclient.version>
-        <reflections.version>0.9.10</reflections.version>
-        <snakeyaml.version>1.21</snakeyaml.version>
+        <httpclient.version>4.5.12</httpclient.version>
+        <reflections.version>0.9.12</reflections.version>
+        <snakeyaml.version>1.26</snakeyaml.version>
         <commons-io.version>2.5</commons-io.version>
         <commons-validator.version>1.4.1</commons-validator.version>
         <json-path.version>2.2.0</json-path.version>
-        <wiremock.version>2.21.0</wiremock.version>
-        <guava.version>26.0-jre</guava.version>
+        <wiremock.version>2.26.3</wiremock.version>
+        <guava.version>29.0-jre</guava.version>
         <powermock.version>2.0.0</powermock.version>
-        <nimbus-jwt.version>8.12</nimbus-jwt.version>
+        <nimbus-jwt.version>8.16</nimbus-jwt.version>
+        <spring-integration.version>5.2.5.RELEASE</spring-integration.version>
     </properties>
 
     <!-- allow snapshot only for vertx until the final release -->


### PR DESCRIPTION
Note: depends on https://github.com/gravitee-io/gravitee-parent/pull/17

spring 5.1.3 -> 5.2.6
netty 4.1.42 -> 4.1.49
jetty 9.4.20 -> 9.4.28
jersey 2.29 -> 2.30.1
jackson 2.9.8 -> 2.10.3
rxjava2 2.2.17 -> 2.2.19
httpclient 4.5.7 -> 4.5.12
relfections 0.9.10 -> 0.9.12
snakeyaml 1.21 -> 1.26
wiremock 2.21.0 -> 2.26.3
guava 26.0-jre -> 29.0-jre
nimbus 8.12 -> 8.16

Closes gravitee-io/issues#3777