### PR TITLE
fix: Change the default values for the number of shards/replicas

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -133,7 +133,7 @@ reporters:
 #      actions: 1000           # Number of requests action before flush
 #      flush_interval: 5       # Flush interval in seconds
 #    settings:
-#      number_of_shards: 5
+#      number_of_shards: 1
 #      number_of_replicas: 1
 #      refresh_interval: 5s
 #    pipeline:


### PR DESCRIPTION
fix gravitee-io/issues#3855