### PR TITLE
feat(elasticsearch): Add default configuration for ES HTTP proxy

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -144,6 +144,18 @@ reporters:
 #      password: secret
 #    http:
 #      timeout: 30000 # in milliseconds
+#      proxy:
+#        type: HTTP #HTTP, SOCK4, SOCK5
+#        http:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
+#        https:
+#          host: localhost
+#          port: 3128
+#          username: user
+#          password: secret
 #    template_mapping:
 #      path: ${gravitee.home}/config/reporter/elasticsearch/templates
 #      extended_request_mapping: request.ftl


### PR DESCRIPTION
Closes gravitee-io/issues#3354