### PR TITLE
TLS Cipher Suite Configuration Option

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerConfiguration.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerConfiguration.java
@@ -45,6 +45,9 @@ public class VertxHttpServerConfiguration implements InitializingBean {
     @Value("${http.ssl.tlsProtocols:#{null}}")
     private String tlsProtocols;
 
+    @Value("${http.ssl.tlsCiphers:#{null}}")
+    private String tlsCiphers;
+
     private ClientAuthMode clientAuth;
 
     @Value("${http.ssl.keystore.type:#{null}}")
@@ -197,6 +200,14 @@ public class VertxHttpServerConfiguration implements InitializingBean {
 
     public void setTlsProtocols(String tlsProtocols) {
         this.tlsProtocols = tlsProtocols;
+    }
+
+    public String getTlsCiphers() {
+        return tlsCiphers;
+    }
+
+    public void setTlsCiphers(String tlsCiphers) {
+        this.tlsCiphers = tlsCiphers;
     }
 
     public int getMaxHeaderSize() {

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerFactory.java
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/src/main/java/io/gravitee/gateway/standalone/vertx/VertxHttpServerFactory.java
@@ -62,8 +62,17 @@ public class VertxHttpServerFactory implements FactoryBean<HttpServer> {
             options.setUseAlpn(httpServerConfiguration.isAlpn());
 
             // TLS protocol support
-            if(httpServerConfiguration.getTlsProtocols() != null) {
+            if (httpServerConfiguration.getTlsProtocols() != null) {
                 options.setEnabledSecureTransportProtocols(new HashSet<>(Arrays.asList(httpServerConfiguration.getTlsProtocols().split("\\s*,\\s*"))));
+            }
+
+            // TLS ciphers support
+            if (httpServerConfiguration.getTlsCiphers() != null) {
+                String[] incomingCipherSuites = httpServerConfiguration.getTlsCiphers().split("\\s*,\\s*");
+                options.getEnabledCipherSuites().clear();
+                for (String cipherSuite: incomingCipherSuites) {
+                    options.addEnabledCipherSuite(cipherSuite);
+                }
             }
 
             if (httpServerConfiguration.isClientAuth() == VertxHttpServerConfiguration.ClientAuthMode.NONE) {

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -28,6 +28,7 @@
 #  ssl:
 #    clientAuth: none # Supports none, request, requires
 #    tlsProtocols: TLSv1.2, TLSv1.3
+#    tlsCiphers: TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
 #    keystore:
 #      type: jks # Supports jks, pem, pkcs12
 #      path: ${gravitee.home}/security/keystore.jks


### PR DESCRIPTION
Closes https://github.com/gravitee-io/issues/issues/4541

To get supported CipherSuites for current java-version do:
jrunscript -e "java.util.Arrays.asList(javax.net.ssl.SSLServerSocketFactory.getDefault().getSupportedCipherSuites()).stream().forEach(println)"