### PR TITLE
feat: auto-enable geoip and user_agent when elasticsearch > 7.x

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -151,7 +151,7 @@ reporters:
 #      refresh_interval: 5s
 #    pipeline:
 #      plugins:
-#        ingest: geoip, user_agent
+#        ingest: geoip, user_agent      # geoip and user_agent are enabled by default for elasticsearch version above 7.x
 #    security:
 #      username: user
 #      password: secret


### PR DESCRIPTION
Fixes https://github.com/gravitee-io/issues/issues/4744