### PR TITLE
chore: rollback parent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20-SNAPSHOT</version>
+        <version>19</version>
     </parent>
 
     <groupId>io.gravitee.gateway</groupId>
@@ -271,6 +271,7 @@
         <nimbus-jwt.version>8.19</nimbus-jwt.version>
         <spring-integration.version>5.2.5.RELEASE</spring-integration.version>
         <protobuf-java.version>3.12.2</protobuf-java.version>
+        <hazelcast.version>4.1.1</hazelcast.version>
         <jmh.version>1.26</jmh.version>
     </properties>
 


### PR DESCRIPTION
and declare hazelcast version in this pom.xml

Fixes gravitee-io/issues#599