### PR TITLE
fix(heartbeat): Define max size on the heartbeat queue to avoid OOM

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/hazelcast.xml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/resources/config/hazelcast.xml
@@ -24,6 +24,12 @@
         <max-size>0</max-size>
     </map>
 
+    <queue name="heartbeats">
+        <!-- By default, gateway emits one event every 5 seconds-->
+        <!-- Keep 1 hour of events -->
+        <max-size>720</max-size>
+    </queue>
+
     <map name="apis">
         <!-- Eviction is managed programmatically-->
         <eviction-policy>NONE</eviction-policy>


### PR DESCRIPTION
Closes gravitee-io/issues#5191