### PR TITLE
Update reporter-api to version 1.20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
         <gravitee-gateway-api.version>1.24.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-alert-api.version>1.6.0</gravitee-alert-api.version>
-        <gravitee-reporter-api.version>1.19.0</gravitee-reporter-api.version>
+        <gravitee-reporter-api.version>1.20.0</gravitee-reporter-api.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <httpclient.version>4.5.12</httpclient.version>


### PR DESCRIPTION
The 1.20 version contains a fix for timestamp logging to file by adding an accessor. This would be very nice to have rolled in.