### PR TITLE
new pipeline defintion to publish snapshot 3.7.0 and be able to use i…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,8 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, nexus_staging, pr_build]
-    default: pr_build
+    enum: [release, standalone_release, nexus_staging, pull_requests]
+    default: pull_requests
   dry_run:
     type: boolean
     default: true
@@ -15,7 +15,7 @@ parameters:
     description: "Maven ID of the Maven profile to use for a dry run ?"
   secrethub_org:
     type: string
-    default: "gravitee-io"
+    default: "graviteeio"
     description: "SecretHub Org to use to fetch secrets ?"
   secrethub_repo:
     type: string
@@ -23,54 +23,211 @@ parameters:
     description: "SecretHub Repo to use to fetch secrets ?"
   s3_bucket_name:
     type: string
-    default: $s3_bucket_name
+    default: $S3_BUCKET_NAME
     description: "Name of the S3 Bucket used to store and retrieve the state of the maven project, to perform the nexus staging ?"
 
 orbs:
+  slack: circleci/slack@4.2.1
   gravitee: gravitee-io/gravitee@dev:1.0.4
+  secrethub: secrethub/cli@1.1.0
+  # secrethub: secrethub/cli@1.0.0
 
 workflows:
   version: 2.1
+  # -- typically this workflow is executed on pull requests events for Community Edition Gravitee Repositories
   pull_requests:
     when:
-      equal: [ pr_build, << pipeline.parameters.gio_action >> ]
+      and:
+        - equal: [ pull_requests, << pipeline.parameters.gio_action >> ]
     jobs:
-      - gravitee/pr-build:
+      - gravitee/d_pull_requests_secrets:
           context: cicd-orchestrator
+          name: pr_secrets_resolution
+      - gravitee/d_pull_requests_ce:
+          name: process_pull_request
+          requires:
+            - pr_secrets_resolution
+          # "What is the maven ID of the maven profile to use to build and deploy SNAPSHOTS to Prviate Artifactory ?"
+          maven_profile_id: 'gio-dev'
+          # nexus_snapshots_url: 'https://oss.sonatype.org/content/repositories/snapshots'
+          # nexus_snapshots_server_id: 'sonatype-nexus-snapshots'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'medium'
+          filters:
+            branches:
+              ignore:
+                - master
+  # ---
+  # The 2 Workflows Below are there for the CICD Orchestrator to be able to
+  # release Gravitee Kubernetes in an APIM release Process, with Docker executors instead of VMs
   release:
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - not: << pipeline.parameters.dry_run >>
     jobs:
-      - gravitee/release:
+      - gravitee/d_release_secrets:
           context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
+          name: release_secrets_resolution
+      - gravitee/d_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: false
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
   release_dry_run:
     when:
       and:
         - equal: [ release, << pipeline.parameters.gio_action >> ]
         - << pipeline.parameters.dry_run >>
     jobs:
-      - gravitee/release:
+      - gravitee/d_release_secrets:
           context: cicd-orchestrator
-          dry_run: << pipeline.parameters.dry_run >>
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
+          name: release_secrets_resolution
+      - gravitee/d_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: true
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
-
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+  # ---
+  # CICD Workflow For APIM Orchestrated Nexus Staging, Container-based : Circle CI Docker Executor
   nexus_staging:
     when:
       equal: [ nexus_staging, << pipeline.parameters.gio_action >> ]
     jobs:
-      - gravitee/nexus_staging:
+      - gravitee/d_nexus_staging_secrets:
           context: cicd-orchestrator
-          secrethub_org: << pipeline.parameters.secrethub_org >>
-          secrethub_repo: << pipeline.parameters.secrethub_repo >>
+          name: nexus_staging_secrets_resolution
+      - gravitee/d_nexus_staging:
+          name: nexus_staging
+          requires:
+            - nexus_staging_secrets_resolution
+          dry_run: << pipeline.parameters.dry_run >>
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          # => If you are running a standalone release, your S3 Bucket name
+          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
+          # => If you are running an Orchestrated release, The Orchestrator knows how to compute the S3 Bucket name
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+  # ---
+  # The 3 Workflows Below are there to perform a "Standalone Release":
+  # => independently of any APIM release Process, with Docker executors instead of VMs
+  # => with chained nexus staging : only when release with dry run mode off
+  standalone_release:
+    when:
+      and:
+        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+        - not: << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_standalone_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: false
           maven_profile_id: << pipeline.parameters.maven_profile_id >>
           s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_release_dry_run:
+    when:
+      and:
+        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+        - << pipeline.parameters.dry_run >>
+    jobs:
+      - gravitee/d_release_secrets:
+          context: cicd-orchestrator
+          name: release_secrets_resolution
+      - gravitee/d_standalone_release:
+          name: maven_n_git_release
+          requires:
+            - release_secrets_resolution
+          dry_run: true
+          maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          s3_bucket_name: << pipeline.parameters.s3_bucket_name >>
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+
+  standalone_nexus_staging:
+    # ---
+    # Running the nexus staging makes sense only when the
+    # standalone release is being performed with dry run mode off
+    # That is to say, when the maven project is ready to be release to mmaven Staging
+    # ---
+    when:
+      and:
+        - equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+        - not: << pipeline.parameters.dry_run >>
+    # ---
+    # Running the nexus staging makes sense only when the
+    # standalone release is being performed with dry run mode off
+    # That is to say, when the maven project is ready to be release to mmaven Staging
+    # Never the less, to test the CICD system, I temporarily git pushed a different configuration
+    # ---
+    # when:
+      # equal: [ standalone_release, << pipeline.parameters.gio_action >> ]
+    jobs:
+      - gravitee/d_nexus_staging_secrets:
+          context: cicd-orchestrator
+          name: nexus_staging_secrets_resolution
+      - nexus_staging_dry_run_approval:
+          type: approval
+          requires:
+            - nexus_staging_secrets_resolution
+      - gravitee/d_standalone_nexus_staging:
+          name: standalone_nexus_staging_dry_run
+          requires:
+            - nexus_staging_dry_run_approval
+            # - nexus_staging_secrets_resolution
+          dry_run: true
+          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: "gravitee-release"
+          # => If you are running a standalone release, your S3 Bucket name
+          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'
+      - nexus_staging_approval:
+          type: approval
+          requires:
+            - nexus_staging_secrets_resolution
+            - standalone_nexus_staging_dry_run
+      - gravitee/d_standalone_nexus_staging:
+          name: standalone_nexus_staging
+          requires:
+            - nexus_staging_approval
+            # - nexus_staging_secrets_resolution
+          dry_run: false
+          # maven_profile_id: << pipeline.parameters.maven_profile_id >>
+          maven_profile_id: "gravitee-release"
+          # => If you are running a standalone release, your S3 Bucket name
+          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
+          # container_gun_image_org: 'circleci'
+          # container_gun_image_name: 'openjdk'
+          # container_gun_image_tag: '11.0.3-jdk-stretch'
+          container_size: 'large'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,6 @@ workflows:
           dry_run: true
           # maven_profile_id: << pipeline.parameters.maven_profile_id >>
           maven_profile_id: "gravitee-release"
-          # => If you are running a standalone release, your S3 Bucket name
-          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
@@ -225,8 +223,6 @@ workflows:
           dry_run: false
           # maven_profile_id: << pipeline.parameters.maven_profile_id >>
           maven_profile_id: "gravitee-release"
-          # => If you are running a standalone release, your S3 Bucket name
-          #    is 'prepared-standalone-nexus-staging-${GRAVITEE_REPO_NAME}-${RELEASE_VERSION_NUMBER}'
           # container_gun_image_org: 'circleci'
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'


### PR DESCRIPTION

## New pipeline defintion to publish snapshot 3.7.0 and be able to use it in gravitee-kuberrnetes


**Do not merge this PR** : 
* It is there to be able to run pull_requests Circle Ci Pipeline Workflow
* to be able to publish `3.7.0-SNAPSHOT` : I have to use it in `gravitee-kubernetes`

N.b.: the source git branch was meant to be named `cicd/pub-snapshot-3.7.0` instead of `cicd/pub-snapshot-1.11.0`, just a mistake because I was going real fast, and this did not hurt the purpose of this git branch : to publish gravitee-gateway 's `3.7.0-SNAPSHOT` version