### PR TITLE
fix(gateway): Consume the queue before releasing the request

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/main/java/io/gravitee/gateway/handlers/api/ApiReactorHandler.java
@@ -199,6 +199,14 @@ public class ApiReactorHandler extends AbstractReactorHandler {
                     context.request().metrics().getApiResponseTimeMs());
         }
         context.setAttribute(ExecutionContext.ATTR_PREFIX + "failure", failure);
+
+        // Ensure we are consuming everything from the inbound queue
+        if (!context.request().ended()) {
+            context.request().bodyHandler(__ -> { });
+            context.request().endHandler(__ -> { });
+            context.request().resume();
+        }
+
         errorProcessorChain
                 .create()
                 .handler(__ -> handler.handle(context))


### PR DESCRIPTION
Closes gravitee-io/issues#5534