### PR TITLE
fix: API health check is duplicating slash in some case

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/rule/EndpointRuleHandler.java
@@ -156,11 +156,14 @@ public abstract class EndpointRuleHandler<T extends Endpoint> implements Handler
             return targetURI;
         }
 
+        final String uri;
         if (path.startsWith("/") || path.startsWith("?")) {
-            return URI.create(targetURI + path);
+            uri = targetURI + path;
+        } else {
+            uri = targetURI + "/" + path;
         }
 
-        return URI.create(targetURI + "/" + path);
+        return URI.create(DUPLICATE_SLASH_REMOVER.matcher(uri).replaceAll("/"));
 
     }
 


### PR DESCRIPTION
Closes gravitee-io/issues#5752