### PR TITLE
Use repo dependencies from the new APIM monorepo - 3.5.x

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/pom.xml
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/pom.xml
@@ -93,8 +93,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerTest.java
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/src/test/java/io/gravitee/gateway/handlers/api/manager/ApiManagerTest.java
@@ -341,7 +341,7 @@ public class ApiManagerTest {
         verify(eventManager).publishEvent(ReactorEvent.DEPLOY, api);
 
         final Api api2 = new Api(api);
-        api2.setDeployedAt(new Date());
+        api2.setDeployedAt(new Date(api.getDeployedAt().getTime()+100));
         api2.setPlans(Collections.<Plan>emptyList());
 
         apiManager.register(api2);

--- a/gravitee-gateway-repository/pom.xml
+++ b/gravitee-gateway-repository/pom.xml
@@ -40,8 +40,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
 
         <dependency>

--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/pom.xml
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/pom.xml
@@ -38,8 +38,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/gravitee-gateway-security/gravitee-gateway-security-jwt/pom.xml
+++ b/gravitee-gateway-security/gravitee-gateway-security-jwt/pom.xml
@@ -39,9 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
-            <version>${gravitee-repository.version}</version>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-security/gravitee-gateway-security-oauth2/pom.xml
+++ b/gravitee-gateway-security/gravitee-gateway-security-oauth2/pom.xml
@@ -39,9 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
-            <version>${gravitee-repository.version}</version>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-services/gravitee-gateway-services-heartbeat/pom.xml
+++ b/gravitee-gateway-services/gravitee-gateway-services-heartbeat/pom.xml
@@ -60,8 +60,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/pom.xml
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/pom.xml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/pom.xml
@@ -440,8 +440,8 @@
                                     <artifactItems>
                                         <!-- REPOSITORIES -->
                                         <artifactItem>
-                                            <groupId>io.gravitee.repository</groupId>
-                                            <artifactId>gravitee-repository-mongodb</artifactId>
+                                            <groupId>io.gravitee.apim.repository</groupId>
+                                            <artifactId>gravitee-apim-repository-mongodb</artifactId>
                                             <version>LATEST</version>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>

--- a/pom.xml
+++ b/pom.xml
@@ -78,9 +78,9 @@
             </dependency>
 
             <dependency>
-                <groupId>io.gravitee.repository</groupId>
-                <artifactId>gravitee-repository</artifactId>
-                <version>${gravitee-repository.version}</version>
+                <groupId>io.gravitee.apim.repository</groupId>
+                <artifactId>gravitee-apim-repository-api</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -247,7 +247,6 @@
         <gravitee-definition.version>1.25.0</gravitee-definition.version>
         <gravitee-common.version>1.19.2</gravitee-common.version>
         <gravitee-expression-language.version>1.4.2</gravitee-expression-language.version>
-        <gravitee-repository.version>3.5.3</gravitee-repository.version>
         <gravitee-plugin-resource.version>1.16.0</gravitee-plugin-resource.version>
         <gravitee-plugin-core.version>1.16.0</gravitee-plugin-core.version>
         <gravitee-plugin-policy.version>1.16.0</gravitee-plugin-policy.version>


### PR DESCRIPTION
**Description**

Use the new APIM mono-repository [gravitee-api-management](https://github.com/gravitee-io/gravitee-api-management) to replace `gravitee-repository`
