### PR TITLE
Use repo dependencies from the new APIM monorepo - 3.0.x

### DIFF
--- a/gravitee-gateway-handlers/gravitee-gateway-handlers-api/pom.xml
+++ b/gravitee-gateway-handlers/gravitee-gateway-handlers-api/pom.xml
@@ -93,8 +93,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-repository/pom.xml
+++ b/gravitee-gateway-repository/pom.xml
@@ -34,8 +34,8 @@
     <dependencies>
         <!-- Gravitee.io dependencies -->
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
 
         <dependency>

--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/pom.xml
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/pom.xml
@@ -38,8 +38,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/gravitee-gateway-security/gravitee-gateway-security-jwt/pom.xml
+++ b/gravitee-gateway-security/gravitee-gateway-security-jwt/pom.xml
@@ -39,9 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
-            <version>${gravitee-repository.version}</version>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-security/gravitee-gateway-security-oauth2/pom.xml
+++ b/gravitee-gateway-security/gravitee-gateway-security-oauth2/pom.xml
@@ -39,9 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
-            <version>${gravitee-repository.version}</version>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-services/gravitee-gateway-services-apikeyscache/pom.xml
+++ b/gravitee-gateway-services/gravitee-gateway-services-apikeyscache/pom.xml
@@ -53,8 +53,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-services/gravitee-gateway-services-heartbeat/pom.xml
+++ b/gravitee-gateway-services/gravitee-gateway-services-heartbeat/pom.xml
@@ -54,8 +54,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-services/gravitee-gateway-services-subscriptions-cache/pom.xml
+++ b/gravitee-gateway-services/gravitee-gateway-services-subscriptions-cache/pom.xml
@@ -53,8 +53,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/pom.xml
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/pom.xml
@@ -39,8 +39,8 @@
         </dependency>
 
         <dependency>
-            <groupId>io.gravitee.repository</groupId>
-            <artifactId>gravitee-repository</artifactId>
+            <groupId>io.gravitee.apim.repository</groupId>
+            <artifactId>gravitee-apim-repository-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-container/pom.xml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-container/pom.xml
@@ -360,8 +360,8 @@
                                     <artifactItems>
                                         <!-- REPOSITORIES -->
                                         <artifactItem>
-                                            <groupId>io.gravitee.repository</groupId>
-                                            <artifactId>gravitee-repository-mongodb</artifactId>
+                                            <groupId>io.gravitee.apim.repository</groupId>
+                                            <artifactId>gravitee-apim-repository-mongodb</artifactId>
                                             <version>LATEST</version>
                                             <type>zip</type>
                                             <overWrite>false</overWrite>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,6 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <!-- <version>19</version> -->
         <version>19.2.1</version>
     </parent>
 
@@ -73,9 +72,9 @@
             </dependency>
 
             <dependency>
-                <groupId>io.gravitee.repository</groupId>
-                <artifactId>gravitee-repository</artifactId>
-                <version>${gravitee-repository.version}</version>
+                <groupId>io.gravitee.apim.repository</groupId>
+                <artifactId>gravitee-apim-repository-api</artifactId>
+                <version>${project.version}</version>
             </dependency>
 
             <dependency>
@@ -242,7 +241,6 @@
         <gravitee-definition.version>1.22.4</gravitee-definition.version>
         <gravitee-common.version>1.17.2</gravitee-common.version>
         <gravitee-expression-language.version>1.4.2</gravitee-expression-language.version>
-        <gravitee-repository.version>3.0.9</gravitee-repository.version>
         <gravitee-plugin-resource.version>1.10.0</gravitee-plugin-resource.version>
         <gravitee-plugin-core.version>1.10.0</gravitee-plugin-core.version>
         <gravitee-plugin-policy.version>1.10.0</gravitee-plugin-policy.version>


### PR DESCRIPTION
**Description**

Use the new APIM mono-repository [gravitee-api-management](https://github.com/gravitee-io/gravitee-api-management) to replace `gravitee-repository`
