### PR TITLE
chore: update gravitee-api-management dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>io.gravitee.apim.repository</groupId>
                 <artifactId>gravitee-apim-repository-api</artifactId>
-                <version>${project.version}</version>
+                <version>${gravitee-api-management.version}</version>
             </dependency>
 
             <dependency>
@@ -259,6 +259,7 @@
         <vertx.version>4.1.0</vertx.version>
         <gravitee-bom.version>1.1</gravitee-bom.version>
         <gravitee-node.version>1.15.1</gravitee-node.version>
+        <gravitee-api-management.version>3.10.0-SNAPSHOT</gravitee-api-management.version>
         <gravitee-definition.version>1.28.0</gravitee-definition.version>
         <gravitee-common.version>1.19.2</gravitee-common.version>
         <gravitee-expression-language.version>1.6.0-SNAPSHOT</gravitee-expression-language.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5821

**Description**

use a specific version for the dependency instead of `project.version`
