### PR TITLE
chore: update gravitee-api-management dependency - 3.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
             <dependency>
                 <groupId>io.gravitee.apim.repository</groupId>
                 <artifactId>gravitee-apim-repository-api</artifactId>
-                <version>${project.version}</version>
+                <version>${gravitee-api-management.version}</version>
             </dependency>
 
             <dependency>
@@ -250,6 +250,7 @@
         <gravitee-policy-api.version>1.7.0</gravitee-policy-api.version>
         <gravitee-alert-api.version>1.5.0</gravitee-alert-api.version>
         <gravitee-reporter-api.version>1.17.1</gravitee-reporter-api.version>
+        <gravitee-api-management.version>3.0.18-SNAPSHOT</gravitee-api-management.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <httpclient.version>4.5.12</httpclient.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5821

**Description**

use a specific version for the dependency instead of `project.version`
