### PR TITLE
chore: update gravitee-api-management dependency - 3.5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
             <dependency>
                 <groupId>io.gravitee.apim.repository</groupId>
                 <artifactId>gravitee-apim-repository-api</artifactId>
-                <version>${project.version}</version>
+                <version>${gravitee-api-management.version}</version>
             </dependency>
 
             <dependency>
@@ -256,6 +256,7 @@
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-alert-api.version>1.6.0</gravitee-alert-api.version>
         <gravitee-reporter-api.version>1.18.0</gravitee-reporter-api.version>
+        <gravitee-api-management.version>3.5.18-SNAPSHOT</gravitee-api-management.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <httpclient.version>4.5.12</httpclient.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5821

**Description**

use a specific version for the dependency instead of `project.version`
