### PR TITLE
chore: update gravitee-api-management dependency - 3.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
             <dependency>
                 <groupId>io.gravitee.apim.repository</groupId>
                 <artifactId>gravitee-apim-repository-api</artifactId>
-                <version>${project.version}</version>
+                <version>${gravitee-api-management.version}</version>
             </dependency>
 
             <dependency>
@@ -276,6 +276,7 @@
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-alert-api.version>1.6.0</gravitee-alert-api.version>
         <gravitee-reporter-api.version>1.20.1</gravitee-reporter-api.version>
+        <gravitee-api-management.version>3.8.6-SNAPSHOT</gravitee-api-management.version>
         <gravitee-service-discovery-api.version>1.1.1</gravitee-service-discovery-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.0.0</gravitee-resource-cache-provider-api.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5821

**Description**

use a specific version for the dependency instead of `project.version`
