### PR TITLE
chore: add runtime library to add LatencyUtils

### DIFF
--- a/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/assembly/distribution.xml
+++ b/gravitee-gateway-standalone/gravitee-gateway-standalone-distribution/src/main/assembly/distribution.xml
@@ -100,6 +100,15 @@
             <scope>compile</scope>
             <useProjectArtifact>false</useProjectArtifact>
         </dependencySet>
+        <dependencySet>
+            <outputDirectory>/lib/ext</outputDirectory>
+            <unpack>false</unpack>
+            <excludes>
+                <exclude>io.gravitee.*:*</exclude>
+            </excludes>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
     </dependencySets>
 </assembly>
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5996

**Description**

Since the migration of micrometer-registry-prometheus from 1.10 to 1.6.2, the LatencyUtils library scope has changed from `compile` to `runtime`
So we need to add runtime dependencies when building distribution.