### PR TITLE
adding new workflow for publishing docker images in Private azure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 parameters:
   gio_action:
     type: enum
-    enum: [release, standalone_release, standalone_release_replay, nexus_staging, vm_nexus_staging, pull_requests]
+    enum: [release, standalone_release, standalone_release_replay, nexus_staging, vm_nexus_staging, pull_requests, snyk_test]
     default: pull_requests
   dry_run:
     type: boolean
@@ -29,9 +29,23 @@ parameters:
     type: string
     default: ''
     description: "What is the version number of the release you want to replay? (Mandatory, only for the 'standalone_release_replay' Workflow / see 'gio_action' pipeline parameter)"
+  docker_latest:
+    type: boolean
+    default: true
+    description: "Is the docker published image a latest?"
+  snyk_test:
+    type: boolean
+    default: false
+    description: "Do we need to publish images in private azure registry for security testing?"
+  repo_test:
+    type: enum
+    enum: [gateway, management-webui, portal-ui, rest-api]
+    default: gateway
+    description: "what repository in azure we need to publish docker image"
 orbs:
   slack: circleci/slack@4.2.1
   gravitee: gravitee-io/gravitee@1.0
+  apim: gravitee-io/gravitee-apim@1.0
   # gravitee: gravitee-io/gravitee@dev:1.0.4
   secrethub: secrethub/cli@1.1.0
   # secrethub: secrethub/cli@1.0.0
@@ -165,7 +179,6 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
-
   standalone_release_dry_run:
     when:
       and:
@@ -261,6 +274,8 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+          
+
 
   standalone_release_replay_dry_run:
     when:
@@ -338,6 +353,25 @@ workflows:
           # container_gun_image_name: 'openjdk'
           # container_gun_image_tag: '11.0.3-jdk-stretch'
           container_size: 'large'
+
+  Docker_Snyk_Test:
+    when:
+      and:
+        - equal: [ snyk_test, << pipeline.parameters.gio_action >> ]
+        - << pipeline.parameters.dry_run >>
+    jobs:
+      - apim/d_apim_package_bundle_secrets:
+          context: cicd-orchestrator
+          name: package_bundle_secrets_resolution
+      - apim/d_apim_snyktest_docker:
+          name: publishing_image_in_azure
+          requires:
+            -  package_bundle_secrets_resolution
+          dry_run: true
+          docker_latest: << pipeline.parameters.docker_latest >>
+          docker_tag: << pipeline.parameters.replayed_release >>
+          snyk_test: << pipeline.parameters.snyk_test >>
+          repo_test: << pipeline.parameters.repo_test >>
 
 
   # ---


### PR DESCRIPTION
Here below CCI pipeline link : it launches the new workflow **"Docker_Snyk_Test"** in non dry run mode, two jobs were added for this workflow : 
- d_apim_package_bundle_secrets
- d_apim_snyktest_docker
in order to fetch Azure secrets from secrethub and then build and publish docker images in azure private registry from a given release that we have to put the version in the parameter,

CCI link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-gateway/1405/workflows/222cddf9-da78-4714-9a6b-f719f5a15025/jobs/2017

Link to the azure private registry : https://portal.azure.com/#@graviteesource.com/resource/subscriptions/02ae5fba-84b0-443a-9df6-9be92297c139/resourceGroups/container-hprod/providers/Microsoft.ContainerRegistry/registries/graviteeio/repository

Link to the slab documentation :  https://gravitee.slab.com/posts/apim-gravitee-gateway-8qakl4x8