### PR TITLE
feat: allow duplicate api keys, find unique apiKey using key & api

### DIFF
--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/src/main/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandler.java
@@ -18,6 +18,7 @@ package io.gravitee.gateway.security.apikey;
 import static io.gravitee.reporter.api.http.SecurityType.API_KEY;
 
 import io.gravitee.common.http.GraviteeHttpHeader;
+import io.gravitee.definition.model.Api;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.security.core.AuthenticationContext;
@@ -63,6 +64,9 @@ public class ApiKeyAuthenticationHandler implements AuthenticationHandler, Initi
     @Autowired
     private ApplicationContext applicationContext;
 
+    @Autowired
+    private Api api;
+
     private ApiKeyRepository apiKeyRepository;
 
     @Override
@@ -82,7 +86,7 @@ public class ApiKeyAuthenticationHandler implements AuthenticationHandler, Initi
             // Get the api-key from the repository if not present in the context
             if (context.get(APIKEY_CONTEXT_ATTRIBUTE) == null) {
                 try {
-                    final Optional<ApiKey> optApiKey = apiKeyRepository.findByKey(apiKey);
+                    final Optional<ApiKey> optApiKey = apiKeyRepository.findByKeyAndApi(apiKey, api.getId());
                     if (optApiKey.isPresent()) {
                         context.request().metrics().setSecurityType(API_KEY);
                         context.request().metrics().setSecurityToken(apiKey);

--- a/gravitee-gateway-security/gravitee-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
+++ b/gravitee-gateway-security/gravitee-gateway-security-apikey/src/test/java/io/gravitee/gateway/security/apikey/ApiKeyAuthenticationHandlerTest.java
@@ -22,6 +22,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.util.LinkedMultiValueMap;
 import io.gravitee.common.util.MultiValueMap;
+import io.gravitee.definition.model.Api;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.security.core.AuthenticationContext;
@@ -70,6 +71,9 @@ public class ApiKeyAuthenticationHandlerTest {
     @Mock
     private ApiKeyRepository apiKeyRepository;
 
+    @Mock
+    private Api api;
+
     @Before
     public void init() {
         initMocks(this);
@@ -79,6 +83,7 @@ public class ApiKeyAuthenticationHandlerTest {
     public void shouldNotHandleRequest() {
         when(authenticationContext.request()).thenReturn(request);
         when(request.headers()).thenReturn(new HttpHeaders());
+        when(api.getId()).thenReturn("api-id");
 
         MultiValueMap<String, String> parameters = mock(MultiValueMap.class);
         when(request.parameters()).thenReturn(parameters);
@@ -91,10 +96,11 @@ public class ApiKeyAuthenticationHandlerTest {
     public void shouldHandleRequestUsingHeaders() throws TechnicalException {
         when(authenticationContext.request()).thenReturn(request);
         when(request.metrics()).thenReturn(metrics);
+        when(api.getId()).thenReturn("api-id");
         HttpHeaders headers = new HttpHeaders();
         headers.set("X-Gravitee-Api-Key", "xxxxx-xxxx-xxxxx");
         when(request.headers()).thenReturn(headers);
-        when(apiKeyRepository.findByKey("xxxxx-xxxx-xxxxx")).thenReturn(of(new ApiKey()));
+        when(apiKeyRepository.findByKeyAndApi("xxxxx-xxxx-xxxxx", "api-id")).thenReturn(of(new ApiKey()));
 
         boolean handle = authenticationHandler.canHandle(authenticationContext);
         Assert.assertTrue(handle);
@@ -106,10 +112,11 @@ public class ApiKeyAuthenticationHandlerTest {
     public void shouldHandleRequestUsingQueryParameters() throws TechnicalException {
         when(authenticationContext.request()).thenReturn(request);
         when(request.metrics()).thenReturn(metrics);
+        when(api.getId()).thenReturn("api-id");
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         parameters.put("api-key", Collections.singletonList("xxxxx-xxxx-xxxxx"));
         when(request.parameters()).thenReturn(parameters);
-        when(apiKeyRepository.findByKey("xxxxx-xxxx-xxxxx")).thenReturn(of(new ApiKey()));
+        when(apiKeyRepository.findByKeyAndApi("xxxxx-xxxx-xxxxx", "api-id")).thenReturn(of(new ApiKey()));
 
         HttpHeaders headers = new HttpHeaders();
         when(request.headers()).thenReturn(headers);

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/apikeys/ApiKeysCacheService.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/apikeys/ApiKeysCacheService.java
@@ -30,6 +30,7 @@ import io.gravitee.gateway.services.sync.apikeys.task.ApiKeyRefresher;
 import io.gravitee.gateway.services.sync.cache.CacheManager;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.management.api.ApiKeyRepository;
+import io.gravitee.repository.management.model.ApiKey;
 import io.vertx.ext.web.Router;
 import java.util.HashMap;
 import java.util.Map;
@@ -218,5 +219,13 @@ public class ApiKeysCacheService extends AbstractService implements EventListene
                 LOGGER.info("API-key refresher already shutdown");
             }
         }
+    }
+
+    public static String buildCacheKey(ApiKey apiKey) {
+        return buildCacheKey(apiKey.getApi(), apiKey.getKey());
+    }
+
+    public static String buildCacheKey(String api, String key) {
+        return String.format("%s.%s", api, key);
     }
 }

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/apikeys/repository/ApiKeyRepositoryWrapper.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/apikeys/repository/ApiKeyRepositoryWrapper.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.gateway.services.sync.apikeys.repository;
 
+import io.gravitee.gateway.services.sync.apikeys.ApiKeysCacheService;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
@@ -39,39 +40,42 @@ public class ApiKeyRepositoryWrapper implements ApiKeyRepository {
     }
 
     @Override
-    public Optional<io.gravitee.repository.management.model.ApiKey> findById(String id) throws TechnicalException {
+    public Optional<ApiKey> findById(String id) throws TechnicalException {
         throw new IllegalStateException();
     }
 
     @Override
-    public Optional<io.gravitee.repository.management.model.ApiKey> findByKey(String apiKey) throws TechnicalException {
-        return Optional.ofNullable(cache.get(apiKey));
-    }
-
-    @Override
-    public io.gravitee.repository.management.model.ApiKey create(io.gravitee.repository.management.model.ApiKey apiKey)
-        throws TechnicalException {
+    public List<ApiKey> findByKey(String apiKey) throws TechnicalException {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<io.gravitee.repository.management.model.ApiKey> findBySubscription(String subscription) throws TechnicalException {
+    public Optional<ApiKey> findByKeyAndApi(String apiKey, String api) throws TechnicalException {
+        return Optional.ofNullable(cache.get(ApiKeysCacheService.buildCacheKey(api, apiKey)));
+    }
+
+    @Override
+    public ApiKey create(io.gravitee.repository.management.model.ApiKey apiKey) throws TechnicalException {
         throw new IllegalStateException();
     }
 
     @Override
-    public Set<io.gravitee.repository.management.model.ApiKey> findByPlan(String plan) throws TechnicalException {
+    public Set<ApiKey> findBySubscription(String subscription) throws TechnicalException {
         throw new IllegalStateException();
     }
 
     @Override
-    public List<io.gravitee.repository.management.model.ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
+    public Set<ApiKey> findByPlan(String plan) throws TechnicalException {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public List<ApiKey> findByCriteria(ApiKeyCriteria filter) throws TechnicalException {
         return wrapped.findByCriteria(filter);
     }
 
     @Override
-    public io.gravitee.repository.management.model.ApiKey update(io.gravitee.repository.management.model.ApiKey apiKey)
-        throws TechnicalException {
+    public ApiKey update(ApiKey apiKey) throws TechnicalException {
         throw new IllegalStateException();
     }
 }

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/apikeys/task/ApiKeyRefresher.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/apikeys/task/ApiKeyRefresher.java
@@ -17,6 +17,7 @@ package io.gravitee.gateway.services.sync.apikeys.task;
 
 import io.gravitee.definition.model.Plan;
 import io.gravitee.gateway.handlers.api.definition.Api;
+import io.gravitee.gateway.services.sync.apikeys.ApiKeysCacheService;
 import io.gravitee.node.api.cluster.ClusterManager;
 import io.gravitee.repository.management.api.ApiKeyRepository;
 import io.gravitee.repository.management.api.search.ApiKeyCriteria;
@@ -137,17 +138,19 @@ public class ApiKeyRefresher implements Runnable {
     }
 
     private void saveOrUpdate(ApiKey apiKey) {
+        String cacheKey = ApiKeysCacheService.buildCacheKey(apiKey);
+
         if (apiKey.isRevoked() || apiKey.isPaused()) {
             logger.debug(
-                "Remove a paused / revoked api-key from cache [key: {}] [plan: {}] [app: {}]",
-                apiKey.getKey(),
+                "Remove a paused / revoked api-key from cache [id: {}] [plan: {}] [app: {}]",
+                apiKey.getId(),
                 apiKey.getPlan(),
                 apiKey.getApplication()
             );
-            cache.remove(apiKey.getKey());
+            cache.remove(cacheKey);
         } else {
-            logger.debug("Cache an api-key [key: {}] [plan: {}] [app: {}]", apiKey.getKey(), apiKey.getPlan(), apiKey.getApplication());
-            cache.put(apiKey.getKey(), new ApiKey(apiKey));
+            logger.debug("Cache an api-key [id: {}] [plan: {}] [app: {}]", apiKey.getId(), apiKey.getPlan(), apiKey.getApplication());
+            cache.put(cacheKey, new ApiKey(apiKey));
         }
     }
 

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/apikeys/ApiKeysCacheServiceTest.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/apikeys/ApiKeysCacheServiceTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.gateway.services.sync.apikeys;
+
+import static org.junit.Assert.assertEquals;
+
+import io.gravitee.repository.management.model.ApiKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/**
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiKeysCacheServiceTest {
+
+    @Test
+    public void buildCacheKey_from_strings_should_concatenate_api_and_key() {
+        String cacheKey = ApiKeysCacheService.buildCacheKey("my-api-id", "my-api-key");
+        assertEquals("my-api-id.my-api-key", cacheKey);
+    }
+
+    @Test
+    public void buildCacheKey_from_apiKey_should_concatenate_api_and_key() {
+        ApiKey apiKey = new ApiKey();
+        apiKey.setApi("my-api-id");
+        apiKey.setKey("my-api-key");
+
+        String cacheKey = ApiKeysCacheService.buildCacheKey(apiKey);
+        assertEquals("my-api-id.my-api-key", cacheKey);
+    }
+}

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/apikeys/repository/ApiKeyRepositoryWrapperTest.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/apikeys/repository/ApiKeyRepositoryWrapperTest.java
@@ -83,11 +83,12 @@ public class ApiKeyRepositoryWrapperTest {
     }
 
     @Test
-    public void shouldFindByKey_empty() throws TechnicalException {
+    public void shouldFindByKeyAndApi_empty() throws TechnicalException {
         String apiKey = "1234-4567-7890";
+        String apiId = "my-Api-Id";
 
-        Mockito.when(cache.get(apiKey)).thenReturn(null);
-        Optional<ApiKey> optApiKey = repository.findByKey(apiKey);
+        Mockito.when(cache.get("my-Api-Id.1234-4567-7890")).thenReturn(null);
+        Optional<ApiKey> optApiKey = repository.findByKeyAndApi(apiKey, apiId);
 
         Assert.assertNotNull(optApiKey);
         Assert.assertFalse(optApiKey.isPresent());
@@ -96,10 +97,11 @@ public class ApiKeyRepositoryWrapperTest {
     @Test
     public void shouldFindByKey_fromCache() throws TechnicalException {
         String apiKey = "1234-4567-7890";
+        String apiId = "my-Api-Id";
         ApiKey mockApiKey = Mockito.mock(ApiKey.class);
 
-        Mockito.when(cache.get(apiKey)).thenReturn(mockApiKey);
-        Optional<ApiKey> optApiKey = repository.findByKey(apiKey);
+        Mockito.when(cache.get("my-Api-Id.1234-4567-7890")).thenReturn(mockApiKey);
+        Optional<ApiKey> optApiKey = repository.findByKeyAndApi(apiKey, apiId);
 
         Assert.assertNotNull(optApiKey);
         Assert.assertTrue(optApiKey.isPresent());

--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/apikeys/task/ApiKeyRepositoryRefresherTest.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/test/java/io/gravitee/gateway/services/sync/apikeys/task/ApiKeyRepositoryRefresherTest.java
@@ -101,7 +101,7 @@ public class ApiKeyRepositoryRefresherTest {
 
         verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         !criteria.isIncludeRevoked() && criteria.getFrom() == 0 && criteria.getTo() == 0 && criteria.getPlans().size() == 1
                 )
@@ -123,7 +123,7 @@ public class ApiKeyRepositoryRefresherTest {
 
         verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         !criteria.isIncludeRevoked() && criteria.getFrom() == 0 && criteria.getTo() == 0 && criteria.getPlans().size() == 1
                 )
@@ -144,7 +144,7 @@ public class ApiKeyRepositoryRefresherTest {
 
         verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         !criteria.isIncludeRevoked() && criteria.getFrom() == 0 && criteria.getTo() == 0 && criteria.getPlans().size() == 1
                 )
@@ -162,7 +162,7 @@ public class ApiKeyRepositoryRefresherTest {
 
         verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         !criteria.isIncludeRevoked() && criteria.getFrom() == 0 && criteria.getTo() == 0 && criteria.getPlans().size() == 1
                 )
@@ -178,7 +178,7 @@ public class ApiKeyRepositoryRefresherTest {
         refresher.initialize();
         refresher.run();
 
-        Mockito.verifyZeroInteractions(apiKeyRepository);
+        Mockito.verifyNoInteractions(apiKeyRepository);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class ApiKeyRepositoryRefresherTest {
         inOrder
             .verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         !criteria.isIncludeRevoked() && criteria.getFrom() == 0 && criteria.getTo() == 0 && criteria.getPlans().size() == 1
                 )
@@ -205,7 +205,7 @@ public class ApiKeyRepositoryRefresherTest {
         inOrder
             .verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         criteria.isIncludeRevoked() && criteria.getFrom() != 0 && criteria.getTo() != 0 && criteria.getPlans().size() == 1
                 )
@@ -218,11 +218,12 @@ public class ApiKeyRepositoryRefresherTest {
         List<Plan> plans = Collections.singletonList(plan);
         when(api.getPlans()).thenReturn(plans);
 
-        ApiKey apiKey1 = Mockito.mock(ApiKey.class);
+        ApiKey apiKey1 = mock(ApiKey.class);
+        when(apiKey1.getApi()).thenReturn("my-api");
         when(apiKey1.getKey()).thenReturn("my-key");
         when(apiKey1.isRevoked()).thenReturn(false);
 
-        when(apiKeyRepository.findByCriteria(Mockito.any(ApiKeyCriteria.class))).thenReturn(Collections.singletonList(apiKey1));
+        when(apiKeyRepository.findByCriteria(any(ApiKeyCriteria.class))).thenReturn(Collections.singletonList(apiKey1));
 
         refresher.initialize();
         refresher.run();
@@ -233,7 +234,7 @@ public class ApiKeyRepositoryRefresherTest {
         inOrder
             .verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         !criteria.isIncludeRevoked() && criteria.getFrom() == 0 && criteria.getTo() == 0 && criteria.getPlans().size() == 1
                 )
@@ -242,13 +243,13 @@ public class ApiKeyRepositoryRefresherTest {
         inOrder
             .verify(apiKeyRepository)
             .findByCriteria(
-                ArgumentMatchers.argThat(
+                argThat(
                     criteria ->
                         criteria.isIncludeRevoked() && criteria.getFrom() != 0 && criteria.getTo() != 0 && criteria.getPlans().size() == 1
                 )
             );
 
-        verify(cache, Mockito.times(2)).put(eq("my-key"), ArgumentMatchers.any(ApiKey.class));
+        verify(cache, Mockito.times(2)).put(eq("my-api.my-key"), any(ApiKey.class));
     }
 
     @Test
@@ -259,15 +260,17 @@ public class ApiKeyRepositoryRefresherTest {
         List<Plan> plans = Collections.singletonList(plan);
         when(api.getPlans()).thenReturn(plans);
 
-        ApiKey apiKey1 = Mockito.mock(ApiKey.class);
+        ApiKey apiKey1 = mock(ApiKey.class);
+        when(apiKey1.getApi()).thenReturn("api-1");
         when(apiKey1.getKey()).thenReturn(apiKey);
         when(apiKey1.isRevoked()).thenReturn(false);
 
-        ApiKey apiKey2 = Mockito.mock(ApiKey.class);
+        ApiKey apiKey2 = mock(ApiKey.class);
+        when(apiKey2.getApi()).thenReturn("api-2");
         when(apiKey2.getKey()).thenReturn(apiKey);
         when(apiKey2.isRevoked()).thenReturn(true);
 
-        when(apiKeyRepository.findByCriteria(Mockito.any(ApiKeyCriteria.class)))
+        when(apiKeyRepository.findByCriteria(any(ApiKeyCriteria.class)))
             .thenReturn(Collections.singletonList(apiKey1))
             .thenReturn(Collections.singletonList(apiKey2));
 
@@ -297,7 +300,7 @@ public class ApiKeyRepositoryRefresherTest {
 
         InOrder inOrderCache = Mockito.inOrder(cache, cache);
 
-        inOrderCache.verify(cache).put(anyString(), any(ApiKey.class));
-        inOrderCache.verify(cache).remove(apiKey);
+        inOrderCache.verify(cache).put(eq("api-1.1234-4567-7890"), any(ApiKey.class));
+        inOrderCache.verify(cache).remove("api-2.1234-4567-7890");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -275,7 +275,7 @@
         <!-- Vert.X version is mandatory for vertx-grpc-protoc-plugin in gravitee-gateway-standalone-container -->
         <vertx.version>4.1.0</vertx.version>
         <gravitee-bom.version>1.2</gravitee-bom.version>
-        <gravitee-api-management.version>3.11.0</gravitee-api-management.version>
+        <gravitee-api-management.version>3.12.0-SNAPSHOT</gravitee-api-management.version>
         <gravitee-definition.version>1.29.0</gravitee-definition.version>
         <gravitee-common.version>1.21.0</gravitee-common.version>
         <gravitee-expression-language.version>1.6.1</gravitee-expression-language.version>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6006

Now we permit multiple API Keys with same key.
To find the unique one, we have to search with two criterias : key and api.