### PR TITLE
ci: init snyk policy file to exclude test code from snyk analysis

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+# Snyk (https://snyk.io) policy file
+version: v1.14.0
+
+exclude:
+  code:
+    - "**/src/test/**"
+


### PR DESCRIPTION
Snyk SAST analysis run against test code leads to unrelevant errors.
This .snyk policy file make snyk ignore code under /src/test/ directories.