### PR TITLE
chore: Upgrade OpenJDK Base Image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,20 +14,21 @@
 # limitations under the License.
 #
 
-FROM adoptopenjdk/openjdk11:jre-11.0.11_9-alpine
+FROM openjdk:11-jre-slim-buster
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0
 ARG GRAVITEEIO_DOWNLOAD_URL=https://download.gravitee.io/graviteeio-apim/distributions
 ENV GRAVITEEIO_HOME /opt/graviteeio-gateway
 
-RUN apk update \
-	&& apk add --update --no-cache zip unzip netcat-openbsd wget \
+RUN apt-get update \
+    && apt-get upgrade \
+    && apt-get --yes install wget unzip htop \
 	&& wget ${GRAVITEEIO_DOWNLOAD_URL}/graviteeio-full-${GRAVITEEIO_VERSION}.zip --no-check-certificate -P /tmp \
     && unzip /tmp/graviteeio-full-${GRAVITEEIO_VERSION}.zip -d /tmp/ \
-	&& apk del zip unzip netcat-openbsd wget \
     && mv /tmp/graviteeio-full-${GRAVITEEIO_VERSION}/graviteeio-gateway* ${GRAVITEEIO_HOME} \
     && rm -rf /tmp/* \
+    && rm -rf /var/lib/apt/lists/* \
 	&& chgrp -R 0 ${GRAVITEEIO_HOME} \
     && chmod -R g=u ${GRAVITEEIO_HOME}
 


### PR DESCRIPTION
Closes gravitee-io/issues#6139