### PR TITLE
fix: fix sync-subscriptions thread prefix

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/subscriptions/SubscriptionsCacheService.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-sync/src/main/java/io/gravitee/gateway/services/sync/subscriptions/SubscriptionsCacheService.java
@@ -121,7 +121,7 @@ public class SubscriptionsCacheService extends AbstractService implements EventL
                     threads,
                     new ThreadFactory() {
                         private int counter = 0;
-                        private String prefix = "gio.sync-apikeys";
+                        private String prefix = "gio.sync-subscriptions";
 
                         @Override
                         public Thread newThread(Runnable r) {


### PR DESCRIPTION
Change sync-subscriptions thread prefix from syn-apikeys to sync-subscriptions.
To avoid duplicate thread names with sync-apikeys.