### PR TITLE
fix: bump gravitee-license-node.version to 1.3.0-SNAPSHOT fixes policies license issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <gravitee-common.version>1.23.0-SNAPSHOT</gravitee-common.version>
         <gravitee-connector-api.version>1.0.0-SNAPSHOT</gravitee-connector-api.version>
         <gravitee-expression-language.version>1.7.1</gravitee-expression-language.version>
-        <gravitee-license-node.version>1.2.1</gravitee-license-node.version>
+        <gravitee-license-node.version>1.3.0-SNAPSHOT</gravitee-license-node.version>
         <gravitee-node.version>1.18.0-SNAPSHOT</gravitee-node.version>
         <gravitee-plugin-resource.version>1.20.0-SNAPSHOT</gravitee-plugin-resource.version>
         <gravitee-plugin-core.version>1.20.0-SNAPSHOT</gravitee-plugin-core.version>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6435