### PR TITLE
fix: bump gravitee-license-node.version to 1.3.0-SNAPSHOT fixes policies licenses issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
         <gravitee-definition.version>1.28.1</gravitee-definition.version>
         <gravitee-common.version>1.20.4-SNAPSHOT</gravitee-common.version>
         <gravitee-expression-language.version>1.6.2</gravitee-expression-language.version>
-        <gravitee-license-node.version>1.2.1</gravitee-license-node.version>
+        <gravitee-license-node.version>1.3.0-SNAPSHOT</gravitee-license-node.version>
         <gravitee-plugin-resource.version>1.16.0</gravitee-plugin-resource.version>
         <gravitee-plugin-core.version>1.16.0</gravitee-plugin-core.version>
         <gravitee-plugin-policy.version>1.16.0</gravitee-plugin-policy.version>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6122