### PR TITLE
Change FROM image in Dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 LABEL maintainer="contact@graviteesource.com"
 
 ARG GRAVITEEIO_VERSION=0


### PR DESCRIPTION
We are moving to the `eclipse-temurin:11-jre-focal` base image for better security.