### PR TITLE
fix: fix healthcheck stopping after gateway restarts

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/EndpointDiscoveryService.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-endpoint-discovery/src/main/java/io/gravitee/gateway/services/endpoint/discovery/EndpointDiscoveryService.java
@@ -67,4 +67,10 @@ public class EndpointDiscoveryService extends AbstractService {
     protected String name() {
         return "Endpoints Discovery";
     }
+
+    @Override
+    public int getOrder() {
+        // ensure service is started before SyncService, as it consumes its events
+        return 900;
+    }
 }

--- a/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckService.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-healthcheck/src/main/java/io/gravitee/gateway/services/healthcheck/EndpointHealthcheckService.java
@@ -67,4 +67,10 @@ public class EndpointHealthcheckService extends AbstractService {
     protected String name() {
         return "Health-check service";
     }
+
+    @Override
+    public int getOrder() {
+        // ensure service is started before SyncService, as it consumes its events
+        return 900;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -265,9 +265,9 @@
         <vertx.version>4.1.3</vertx.version>
         <gravitee-bom.version>1.4</gravitee-bom.version>
         <gravitee-api-management.version>3.10.4-SNAPSHOT</gravitee-api-management.version>
-        <gravitee-node.version>1.16.2</gravitee-node.version>
+        <gravitee-node.version>1.16.3-SNAPSHOT</gravitee-node.version>
         <gravitee-definition.version>1.28.1</gravitee-definition.version>
-        <gravitee-common.version>1.20.3</gravitee-common.version>
+        <gravitee-common.version>1.20.4-SNAPSHOT</gravitee-common.version>
         <gravitee-expression-language.version>1.6.2</gravitee-expression-language.version>
         <gravitee-license-node.version>1.2.1</gravitee-license-node.version>
         <gravitee-plugin-resource.version>1.16.0</gravitee-plugin-resource.version>


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6306

fix: fix healthcheck stopping after gateway restarts

Ensure EndpointDiscoveryService and EndpointHealthcheck services are started before the SyncService,
As they consume events produced by SyncService.

We choose to override the getOrder() for EndpointDiscoveryService and EndpointHealthcheck, instead of increasing the SyncService one,
Cause we will get rid of those both services plugin in future versions.
