### PR TITLE
fix: fix irrelevant WARN message when a TemplateVariableProvider is n…

### DIFF
--- a/gravitee-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/context/TemplateVariableProviderFactory.java
+++ b/gravitee-gateway-reactor/src/main/java/io/gravitee/gateway/reactor/handler/context/TemplateVariableProviderFactory.java
@@ -51,8 +51,11 @@ public abstract class TemplateVariableProviderFactory {
                     try {
                         Class<TemplateVariableProvider> instance = (Class<TemplateVariableProvider>) ClassUtils.forName(name, classLoader);
                         return applicationContext.getBean(instance);
-                    } catch (ClassNotFoundException | NoSuchBeanDefinitionException e) {
-                        logger.warn(e.getMessage());
+                    } catch (ClassNotFoundException e) {
+                        logger.warn("TemplateVariableProvider class not found : {}", e.getMessage());
+                        return null;
+                    } catch (NoSuchBeanDefinitionException e) {
+                        logger.debug("No TemplateVariableProvider of type {} is defined", name);
                         return null;
                     }
                 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6105

This warning does not reflect a problem.
Some TemplateVariableProviders are not defined, and this is a normal behavior.
The WARN log level is not relevant here, and has to be set to DEBUG.

When a ClassNotFoundException occurs, this is a real problem, and still has to be logged in WARN.