### PR TITLE
Add possibility to pre-define Vertx HTTP Server host name and port

### DIFF
--- a/gravitee-gateway-services/gravitee-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
+++ b/gravitee-gateway-services/gravitee-gateway-services-debug/src/main/java/io/gravitee/gateway/debug/vertx/VertxDebugConfiguration.java
@@ -73,7 +73,12 @@ public class VertxDebugConfiguration {
 
     @Bean("debugHttpServerConfiguration")
     public HttpServerConfiguration debugHttpServerConfiguration(Environment environment) {
-        return HttpServerConfiguration.builder().withEnvironment(environment).withDefaultPort(8482).withDefaultHost("localhost").build();
+        return HttpServerConfiguration
+            .builder()
+            .withEnvironment(environment)
+            .withPort(Integer.parseInt(environment.getProperty("debug.http.port", "8482")))
+            .withHost(environment.getProperty("debug.http.host", "localhost"))
+            .build();
     }
 
     @Bean("gatewayDebugHttpServer")


### PR DESCRIPTION
Issue: https://github.com/gravitee-io/issues/issues/6568
First this PR needs to be merged: https://github.com/gravitee-io/gravitee-node/pull/93