### PR TITLE
Improve dev docker images generation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,12 @@ jobs:
             --build-arg GRAVITEEIO_VERSION=${APIM_VERSION} \
             -t ${IMAGE_TAG} .
 
+            if [[ $CIRCLE_BRANCH =~ ^([0-9]+\.[0-9]+\.x|master)$ ]]
+            then
+              docker login --username="${DOCKERHUB_BOT_USER_NAME}" -p="${DOCKERHUB_BOT_USER_TOKEN}"
+              docker push ${IMAGE_TAG}
+            fi
+
             echo $AZURE_DOCKER_REGISTRY_PASSWORD | docker login --username $AZURE_DOCKER_REGISTRY_USERNAME --password-stdin graviteeio.azurecr.io
             docker push ${IMAGE_TAG}
       - persist_to_workspace:
@@ -278,6 +284,12 @@ workflows:
             - secrethub/env-export:
                 secret-path: graviteeio/cicd/azure/docker-registries/graviteeio/password
                 var-name: AZURE_DOCKER_REGISTRY_PASSWORD
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-name
+                var-name: DOCKERHUB_BOT_USER_NAME
+            - secrethub/env-export:
+                secret-path: graviteeio/cicd/graviteebot/infra/dockerhub-user-token
+                var-name: DOCKERHUB_BOT_USER_TOKEN
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,8 +143,13 @@ jobs:
       - run:
           name: Compute Tag for Docker images
           command: |
-            # Compute tag with branch name, commmit SHA and timestamp. Then slugify it to be sure it can be handled by Docker
-            export TAG=${APIM_VERSION}-$(echo "${CIRCLE_BRANCH:0:15}" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)-${CIRCLE_SHA1:0:7}
+            if [[ $CIRCLE_BRANCH =~ ^([0-9]+\.[0-9]+\.x|master)$ ]]
+            then
+              export TAG=${CIRCLE_BRANCH}-latest
+            else
+              # Compute tag with branch name, commmit SHA and timestamp. Then slugify it to be sure it can be handled by Docker
+              export TAG=${APIM_VERSION}-$(echo "${CIRCLE_BRANCH:0:15}" | sed -E 's/[~^]+//g' | sed -E 's/[^a-zA-Z0-9]+/-/g' | sed -E 's/^-+|-+$//g' | tr A-Z a-z)-${CIRCLE_SHA1:0:7}
+            fi
             # Workaround for sharing this variable to the next steps
             echo "export TAG=$TAG" >> $BASH_ENV
             echo "Docker images will be tagged with: ${TAG}"
@@ -220,12 +225,14 @@ jobs:
             # FIXME: change redis.repositoryVersion
             helm upgrade --repo https://helm.gravitee.io \
                          --install apim \
-                        -n ${K8S_NAMESPACE} \
+                         -n ${K8S_NAMESPACE} \
                          apim3 \
                          --reuse-values \
                          --set "gateway.image.repository=graviteeio.azurecr.io/apim-gateway" \
                          --set "gateway.image.tag=${TAG}" \
                          --set "redis.repositoryVersion=3.12.1"
+
+            kubectl rollout restart deployment/apim-apim3-gateway -n ${K8S_NAMESPACE}
 
 workflows:
   version: 2.1


### PR DESCRIPTION
The goal of this PR is to be able to use always the same tag when we create a docker image for APIM from master or any support branches.
This tag would be called `BranchName`-latest.

On top of that, we would push these tags on dockerhub.