### PR TITLE
fix: bump gravitee-gateway-api version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,7 +301,7 @@
         <gravitee-plugin-alert.version>1.20.0</gravitee-plugin-alert.version>
         <gravitee-plugin-service-discovery.version>1.20.0</gravitee-plugin-service-discovery.version>
         <gravitee-plugin-connector.version>1.20.0</gravitee-plugin-connector.version>
-        <gravitee-gateway-api.version>1.29.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.30.0-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
         <gravitee-alert-api.version>1.8.0</gravitee-alert-api.version>
         <gravitee-reporter-api.version>1.21.0</gravitee-reporter-api.version>


### PR DESCRIPTION
Related to https://github.com/gravitee-io/issues/issues/6574

Bump was missing in https://github.com/gravitee-io/gravitee-gateway/pull/818